### PR TITLE
Escaping of values and fixes a bug with UTF-16 Chars

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,48 +1,57 @@
 var fs = require('fs');
-var Iconv = require('iconv').Iconv;
-var iconv = new Iconv('UTF-8', 'UTF-16');
 
-exports.generator = function(data, fileName) {
-  var header, body, footer, dataKeys;
+var escapeString = function escapeString(value) {
+    var out = value.toString();
+    out = out.replace(/\\/g, "\\\\");
+    out = out.replace(/\(/g, "\\(");
+    out = out.replace(/\)/g, "\\)");
+    out = out.toString("utf8");
+    console.log(out)
+    return out;
+}
 
-  header = Buffer([]);
-  header = Buffer.concat([ header, new Buffer("%FDF-1.2\n") ]);
-  header = Buffer.concat([ header, new Buffer((String.fromCharCode(226)) + (String.fromCharCode(227)) + (String.fromCharCode(207)) + (String.fromCharCode(211)) + "\n") ]);
-  header = Buffer.concat([ header, new Buffer("1 0 obj \n") ]);
-  header = Buffer.concat([ header, new Buffer("<<\n") ]);
-  header = Buffer.concat([ header, new Buffer("/FDF \n") ]);
-  header = Buffer.concat([ header, new Buffer("<<\n") ]);
-  header = Buffer.concat([ header, new Buffer("/Fields [\n") ]);
+exports.generator = function (data, fileName) {
+    var header, body, footer, dataKeys;
 
-  footer = Buffer([]);
-  footer = Buffer.concat([ footer, new Buffer("]\n") ]);
-  footer = Buffer.concat([ footer, new Buffer(">>\n") ]);
-  footer = Buffer.concat([ footer, new Buffer(">>\n") ]);
-  footer = Buffer.concat([ footer, new Buffer("endobj \n") ]);
-  footer = Buffer.concat([ footer, new Buffer("trailer\n") ]);
-  footer = Buffer.concat([ footer, new Buffer("\n") ]);
-  footer = Buffer.concat([ footer, new Buffer("<<\n") ]);
-  footer = Buffer.concat([ footer, new Buffer("/Root 1 0 R\n") ]);
-  footer = Buffer.concat([ footer, new Buffer(">>\n") ]);
-  footer = Buffer.concat([ footer, new Buffer("%%EOF\n") ]);
+    header = Buffer([]);
+    header = Buffer.concat([header, new Buffer("%FDF-1.2\n")]);
+    header = Buffer.concat([header, new Buffer((String.fromCharCode(226)) + (String.fromCharCode(227)) + (String.fromCharCode(207)) + (String.fromCharCode(211)) + "\n")]);
+    header = Buffer.concat([header, new Buffer("1 0 obj \n")]);
+    header = Buffer.concat([header, new Buffer("<<\n")]);
+    header = Buffer.concat([header, new Buffer("/FDF \n")]);
+    header = Buffer.concat([header, new Buffer("<<\n")]);
+    header = Buffer.concat([header, new Buffer("/Fields [\n")]);
 
-  dataKeys = Object.keys(data);
+    footer = Buffer([]);
+    footer = Buffer.concat([footer, new Buffer("]\n")]);
+    footer = Buffer.concat([footer, new Buffer(">>\n")]);
+    footer = Buffer.concat([footer, new Buffer(">>\n")]);
+    footer = Buffer.concat([footer, new Buffer("endobj \n")]);
+    footer = Buffer.concat([footer, new Buffer("trailer\n")]);
+    footer = Buffer.concat([footer, new Buffer("\n")]);
+    footer = Buffer.concat([footer, new Buffer("<<\n")]);
+    footer = Buffer.concat([footer, new Buffer("/Root 1 0 R\n")]);
+    footer = Buffer.concat([footer, new Buffer(">>\n")]);
+    footer = Buffer.concat([footer, new Buffer("%%EOF\n")]);
 
-  body = new Buffer([]);
+    dataKeys = Object.keys(data);
 
-  for(var i=0; i<dataKeys.length; i++) {
-    var name = dataKeys[i];
-    var value = data[name];
+    body = new Buffer([]);
 
-    body = Buffer.concat([ body, new Buffer("<<\n") ]);
-    body = Buffer.concat([ body, new Buffer("/T (") ]);
-    body = Buffer.concat([ body, iconv.convert(name.toString()) ]);
-    body = Buffer.concat([ body, new Buffer(")\n") ]);
-    body = Buffer.concat([ body, new Buffer("/V (") ]);
-    body = Buffer.concat([ body, iconv.convert(value.toString()) ]);
-    body = Buffer.concat([ body, new Buffer(")\n") ]);
-    body = Buffer.concat([ body, new Buffer(">>\n") ]);
-  }
+    for (var i = 0; i < dataKeys.length; i++) {
+        var name = dataKeys[i];
+        var value = data[name];
 
-  fs.writeFileSync(fileName, Buffer.concat([ header, body, footer ]));
+        body = Buffer.concat([body, new Buffer("<<\n")]);
+        body = Buffer.concat([body, new Buffer("/T (")]);
+
+        body = Buffer.concat([body, new Buffer(escapeString(name))]);
+        body = Buffer.concat([body, new Buffer(")\n")]);
+        body = Buffer.concat([body, new Buffer("/V (")]);
+        body = Buffer.concat([body, new Buffer(escapeString(value))]);
+        body = Buffer.concat([body, new Buffer(")\n")]);
+        body = Buffer.concat([body, new Buffer(">>\n")]);
+    }
+
+    fs.writeFileSync(fileName, Buffer.concat([header, body, footer]));
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "type": "git",
     "url": "https://github.com/Rhaseven7h/utf8-fdf-generator.git"
   },
-  "dependencies": {
-    "iconv": "*"
+  "dependencies": {    
   },
   "engines": {
     "node": "*"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Gabriel Medina <rha7.com@gmail.com>",
   "name": "utf8-fdf-generator",
   "description": "Generates FDF (PDF form input) files with UTF-8 support.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "keywords": [ "pdf", "fdf", "fill", "form", "generator" ],
   "main": "./lib/generator.js",
   "license": "MIT",


### PR DESCRIPTION
Hi,
  Thank you so much for this library, it saved me a lot of time.  We ran in to a bug when a user submitted data with a ( or ).  After some research we found that in the fdf files, we need to escape them.  When we escaped them the UTF-16 converter ended up causing the fdf to get saved with binary chars in them, since the write file saves as a UTF8 file by default.  

I made some small changes and the now the (, ), and \ are escaped properly.

Thanks again,
-James